### PR TITLE
Downloadable version of phantomjs, and download from mirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "make test"
   },
   "config": {
-    "phantomjs_version": "1.9.8"
+    "phantomjs_version": "2.1.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:jmervine/phapper.git"
+    "url": "git@github.com:alphara/phapper.git"
   },
   "keywords": [
     "phantomjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phapper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "PhantomJS Script wrapper for Node.",
   "main": "./lib/phapper.js",
   "engines": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 libdir="$(echo $(cd $(dirname $0)/..; pwd)/lib)"
-srcpath="https://bitbucket.org/ariya/phantomjs/downloads"
+srcpath="http://cnpmjs.org/downloads"
 if test "$npm_config_phantomjs_version"; then
   version="$npm_config_phantomjs_version"
 else


### PR DESCRIPTION
Hey, jmervine.

I updated version of phantomjs to 2.1.1.

And made download from mirror:

-srcpath="https://bitbucket.org/ariya/phantomjs/downloads"
+srcpath="http://cnpmjs.org/downloads"

bitbucket.org has problems with downloads. Sometimes file is not accessible.
